### PR TITLE
Deduplicate results and other refinements

### DIFF
--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,4 +1,5 @@
 local fzf_lua_grep = require("fzf-lua/providers/grep")
+local utils = require("utils")
 
 local types = {
   ts = {
@@ -11,6 +12,13 @@ local types = {
   },
 }
 
+local live_grep = function(search_fn)
+  return function(opts)
+    opts.search = search_fn and search_fn() or nil
+    fzf_lua_grep.live_grep(opts)
+  end
+end
+
 local M = {}
 
 M.filetypes = {
@@ -20,8 +28,9 @@ M.filetypes = {
 }
 
 M.commands = {
-  live_grep = fzf_lua_grep.live_grep,
-  grep_cword = fzf_lua_grep.grep_cword,
+  live_grep = live_grep(),
+  grep_visual = live_grep(utils.get_visual_selection),
+  grep_cword = live_grep(utils.get_cword),
 }
 
 return M

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -6,7 +6,7 @@ local types = {
     -- eg. import * as mobx from 'mobx'
     -- eg. import styles from "myfile.css"
     -- does not match relative paths like import styles from "./myfile.css" (can be disabled by removing the \w at the end)
-    regex = "^import\\s*(type\\s+)?(\\*?\\s*\\{[^}]*%s[^}]*\\}|\\*?\\s*%s)\\s*from\\s[\\\"\\']\\w",
+    regex = "^import\\s*(type\\s+)?(\\*?\\s*\\{[^}]%s[^}]*\\}|\\*?\\s%s)\\s*from\\s[\\\"\\']\\w",
     glob = { "ts", "tsx", "js", "jsx" },
   },
 }

--- a/lua/fzf-lua-import.lua
+++ b/lua/fzf-lua-import.lua
@@ -1,6 +1,7 @@
 local commands = require("config")
 local utils = require("utils")
 local actions = require("actions")
+local make_entry = require("fzf-lua.make_entry")
 
 local M = {
   config = {
@@ -36,6 +37,18 @@ local create_rg_glob_fn = function(filetype_opts)
   end
 end
 
+-- Filter out duplicates
+local create_fn_transform = function(opts)
+  local results = {}
+
+  return function(x)
+    if results[x] == nil then
+      results[x] = true
+      return make_entry.file(x, opts)
+    end
+  end
+end
+
 M.import = function(opts)
   local command = commands.commands[opts.args]
 
@@ -46,6 +59,7 @@ M.import = function(opts)
     if filetype_opts then
       command(vim.tbl_deep_extend("keep", {
         rg_glob_fn = create_rg_glob_fn(filetype_opts),
+        fn_transform = create_fn_transform(M.config.fzf_lua_opts),
       }, M.config.fzf_lua_opts))
     else
       return print("Unsupported filetype: " .. filetype)

--- a/lua/fzf-lua-import.lua
+++ b/lua/fzf-lua-import.lua
@@ -22,7 +22,8 @@ local M = {
     },
     keys = {
       { key = "<leader>ci", mode = { "n" }, command = "live_grep", enabled = true },
-      { key = "<leader>cI", mode = { "n" }, command = "grep_cword", enabled = true },
+      { key = "<leader>ci", mode = { "v" }, command = "grep_visual", enabled = true },
+      { key = "<leader>cI", mode = { "v", "n" }, command = "grep_cword", enabled = true },
     },
   },
 }

--- a/lua/fzf-lua-import.lua
+++ b/lua/fzf-lua-import.lua
@@ -42,6 +42,11 @@ local create_fn_transform = function(opts)
   local results = {}
 
   return function(x)
+    -- Every now and then clear the results
+    if vim.tbl_count(results) > 1000 then
+      results = {}
+    end
+
     if results[x] == nil then
       results[x] = true
       return make_entry.file(x, opts)

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -32,4 +32,12 @@ M.line_exists_in_buffer = function(line, buffer)
   return false
 end
 
+M.get_visual_selection = function()
+  return fzf_lua_utils.get_visual_selection()
+end
+
+M.get_cword = function()
+  return vim.fn.expand("<cword>")
+end
+
 return M


### PR DESCRIPTION
* Add a transformer that does a local check for duplicates and ignores values if found.
  * Clear out local cache every 1000 results to avoid memory leak. This means there may be a duplicate every 1000 results.
* Refine regex so the search results must start with the query
* Add a visual mode option, also set to `<leader>ci`
* All commands go through live grep for better colors and to ensure duplication works 